### PR TITLE
Disable inactive card sets by default.

### DIFF
--- a/build.properties.example
+++ b/build.properties.example
@@ -1,7 +1,7 @@
 pyx.cookie_domain=.localhost
 pyx.max_users=100
 pyx.max_games=25
-pyx.include_inactive_cardsets=true
+pyx.include_inactive_cardsets=false
 pyx.broadcast_connects_and_disconnects=true
 pyx.global_chat_enabled=true
 pyx.game_chat_enabled=true


### PR DESCRIPTION
Not sure why this was enabled by default. Kind-of fixes #192.